### PR TITLE
Mobile responsiveness for "Intro to python" page

### DIFF
--- a/src/Python_Library_Pages/Python_Basics/Introduction-to-Python.jsx
+++ b/src/Python_Library_Pages/Python_Basics/Introduction-to-Python.jsx
@@ -2,7 +2,7 @@ import React from "react";
 
 const PythonBasics = () => {
   return (
-    <div>
+    <div className="python-intro">
 
       <h1><b>1. Introduction to Python</b></h1>
       <br />

--- a/src/index.css
+++ b/src/index.css
@@ -25,3 +25,31 @@
 .active {
   @apply bg-blue-100 text-blue-600;
 }
+
+/* Mobile styles for intro-to-python page */
+@media (max-width: 640px) {
+
+  .python-intro pre {
+      font-size: 0.875rem; 
+      overflow-x: auto; 
+  }
+
+  .python-intro h1 {
+      font-size: 1.5rem;
+      line-height: 1.4;
+  }
+
+  .python-intro h2 {
+      font-size: 1.25rem;
+      line-height: 1.3;
+  }
+
+  .python-intro h4 {
+      font-size: 1rem;
+  }
+
+  .python-intro li {
+      margin-bottom: 0.5rem;
+  }
+
+}


### PR DESCRIPTION
This PR addresses the responsiveness issue #207 for the "Intro to python" section. The previous styles were not optimized for mobile view, making some elements disproportionate and hard to read on smaller screens.

Before

https://github.com/thecuriousteam/PyLibLog/assets/122199576/d0268346-d9a7-49ec-b3cc-afdb106b65be

Now

https://github.com/thecuriousteam/PyLibLog/assets/122199576/563919af-6029-4b55-8cbb-5f81e1ce4c40



